### PR TITLE
chore(agent): some tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ LIVEKIT_API_KEY=<your API Key>
 LIVEKIT_API_SECRET=<your API Secret>
 LIVEKIT_SANDBOX_ID=<your Sandbox ID>
 OPENAI_API_KEY=<To use other providers, press Enter for now and edit .env.local>
+DEEPGRAM_API_KEY=<To use other providers, press Enter for now and edit .env.local>

--- a/README.md
+++ b/README.md
@@ -20,17 +20,23 @@ A basic example of a voice agent using LiveKit and Python.
 
 Clone the repository and install dependencies to a virtual environment:
 
-```bash
-cd python-voice-agent
+```console
+cd pipeline-voice-agent-python
 python3 -m venv venv
 source venv/bin/activate
-python3 -m pip install -r requirements.txt
+pip install -r requirements.txt
 ```
 
 Set up the environment by copying `.env.example` to `.env.local` and filling in the required values, or by using the LiveKit CLI:
 
-```bash
+```console
 lk app env
+```
+
+Run the agent:
+
+```console
+python3 agent.py dev
 ```
 
 This agent requires a frontend application to communicate with. You can use one of our example frontends in [livekit-examples](https://github.com/livekit-examples/), create your own following one of our [client quickstarts](https://docs.livekit.io/realtime/quickstarts/), or test instantly against one of our hosted [Sandbox](https://cloud.livekit.io/projects/p_/sandbox) frontends.

--- a/agent.py
+++ b/agent.py
@@ -12,7 +12,7 @@ from livekit.agents import (
     llm,
 )
 from livekit.agents.voice_assistant import VoiceAssistant
-from livekit.plugins import openai, silero
+from livekit.plugins import openai, deepgram, silero
 
 
 load_dotenv(dotenv_path=".env.local")
@@ -50,8 +50,8 @@ async def entrypoint(ctx: JobContext):
     # https://docs.livekit.io/agents/plugins
     assistant = VoiceAssistant(
         vad=ctx.proc.userdata["vad"],
-        stt=openai.STT(model="whisper-1"),
-        llm=openai.LLM(),
+        stt=deepgram.STT(),
+        llm=openai.LLM(model="gpt-4o-mini"),
         tts=openai.TTS(),
         chat_ctx=initial_ctx,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 livekit-agents>=0.9.1
 livekit-plugins-openai>=0.8.5
+livekit-plugins-deepgram>=0.6.7
 livekit-plugins-silero>=0.6.4
 python-dotenv~=1.0
 aiofile~=3.8.8

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -13,8 +13,8 @@ tasks:
         cmd: echo -e "    source venv/bin/activate\r"
       - platforms: [windows]
         cmd: echo -e "    powershell venv/Scripts/Activate.ps1\r"
-      - echo -e "    python3 -m pip install -r requirements.txt\r"
-      - echo -e "    python3 agent.py start\r\n"
+      - echo -e "    pip install -r requirements.txt\r"
+      - echo -e "    python3 agent.py dev\r\n"
 
   install:
     desc: "Bootstrap application for local development"
@@ -24,7 +24,7 @@ tasks:
         cmd: "source venv/bin/activate"
       - platforms: [windows]
         cmd: "powershell venv/Scripts/Activate.ps1"
-      - "python3 -m pip install -r requirements.txt"
+      - "pip install -r requirements.txt"
 
   dev:
     interactive: true
@@ -33,4 +33,4 @@ tasks:
         cmd: "source venv/bin/activate"
       - platforms: [windows]
         cmd: "powershell venv/Scripts/Activate.ps1"
-      - "python3 agent.py start"
+      - "python3 agent.py dev"


### PR DESCRIPTION
https://linear.app/livekit/issue/DEX-798/pipeline-voice-agent-python

- [x] change install requirement step to `pip install -r requirements.txt`, does not need `python3 -m`
- [x] change start to `python3 agent.py dev` , dev mode is optimized for running locally
- [x] should use Deepgram for STT, OAI STT is not streaming and is not as good
- [x] use `gpt-4o-mini by default`, due to price & performance
- [ ] need to point to agents 0.10.0 as dependency